### PR TITLE
Ambassador (Emissary-Ingress)

### DIFF
--- a/kubernetes/gke/ingress/ambassador/README.md
+++ b/kubernetes/gke/ingress/ambassador/README.md
@@ -1,0 +1,30 @@
+
+Originally, there was a popular ingress called **Ambassador**, but this has been been renamed to **emissary-ingress**.  **Ambassador** (not to be confused with **Ambassador**) has a enterprise version of this called **Ambassador Edge Stack**.  The enterprise product requires contacting the sales department to get a license, while the OSS is available without any hassle.  Given this, the OSS **emissary-ingress** will be covered in this area. 
+
+Emissary-Ingress is built around the Envoy Proxy as its core proxy.  Envoy was build and open source in 2016 by Lyft. 
+
+## Installation
+
+```bash
+# Add the Repo:
+helm repo add datawire https://app.getambassador.io && helm repo update
+ 
+# Create Namespace and Install:
+kubectl create namespace emissary && \
+  kubectl apply -f https://app.getambassador.io/yaml/emissary/3.9.0/emissary-crds.yaml
+ 
+kubectl wait --timeout=90s --for=condition=available deployment emissary-apiext --namespace emissary-system
+ 
+helm install emissary-ingress --namespace emissary datawire/emissary-ingress
+
+kubectl --namespace emissary wait --for condition=available --timeout=90s deploy --selector app.kubernetes.io/instance=emissary-ingress
+```
+
+
+## Articles 
+
+* [Envoy Proxy 101: What it is, and why it matters?]https://www.getambassador.io/learn/envoy-proxy)
+* [Envoy Gateway Offers to Standardize Kubernetes Ingress](https://thenewstack.io/envoy-gateway-offers-to-standardize-kubernetes-ingress/) by Joab Jackson (The New Stack) on May 16, 2022
+* [Lyft’s Envoy: From Monolith to Service Mesh – Matt Klein](https://www.microservices.com/talks/lyfts-envoy-monolith-service-mesh-matt-klein/) video by Matt Klein (Lyft)
+* [Introducing Envoy Gateway: An Envoy Proxy-based Gateway for Kubernetes](https://blog.getambassador.io/introducing-envoy-gateway-5b3df54e5f9b) by Richard Li on May 16, 2022
+* [From Monolith to Service Mesh, via a Front Proxy — Learnings from stories of building the Envoy Proxy](https://itnext.io/from-monolith-to-service-mesh-via-a-front-proxy-learnings-from-stories-of-building-the-envoy-9dab4b721089)

--- a/kubernetes/gke/ingress/ambassador/README.md
+++ b/kubernetes/gke/ingress/ambassador/README.md
@@ -1,7 +1,8 @@
+# Emissary-Ingress (previously known as Ambassador)
 
 Originally, there was a popular ingress called **Ambassador**, but this has been been renamed to **emissary-ingress**.  **Ambassador** (not to be confused with **Ambassador**) has a enterprise version of this called **Ambassador Edge Stack**.  The enterprise product requires contacting the sales department to get a license, while the OSS is available without any hassle.  Given this, the OSS **emissary-ingress** will be covered in this area. 
 
-Emissary-Ingress is built around the Envoy Proxy as its core proxy.  Envoy was build and open source in 2016 by Lyft. 
+Emissary-Ingress is built around the [Envoy Proxy](https://www.envoyproxy.io/) as its core proxy.  [Envoy Proxy](https://www.envoyproxy.io/) was built and open sourced in 2016 by Lyft. 
 
 ## Installation
 
@@ -11,7 +12,7 @@ helm repo add datawire https://app.getambassador.io && helm repo update
  
 # Create Namespace and Install:
 kubectl create namespace emissary && \
-  kubectl apply -f https://app.getambassador.io/yaml/emissary/3.9.0/emissary-crds.yaml
+  kubectl apply --filename https://app.getambassador.io/yaml/emissary/3.9.0/emissary-crds.yaml
  
 kubectl wait --timeout=90s --for=condition=available deployment emissary-apiext --namespace emissary-system
  
@@ -20,6 +21,13 @@ helm install emissary-ingress --namespace emissary datawire/emissary-ingress
 kubectl --namespace emissary wait --for condition=available --timeout=90s deploy --selector app.kubernetes.io/instance=emissary-ingress
 ```
 
+## Clean
+
+```bash
+helm delete emissary-ingress --namespace emissary
+kubectl delete --filename https://app.getambassador.io/yaml/emissary/3.9.0/emissary-crds.yaml
+kubectl delete ns emissary
+```
 
 ## Articles 
 

--- a/kubernetes/gke/ingress/ambassador/example/apache/README.md
+++ b/kubernetes/gke/ingress/ambassador/example/apache/README.md
@@ -1,0 +1,35 @@
+# Apache HTTPd Examples
+
+
+This is a basic test of ingress features using Apache HTTPd.
+
+## Install
+
+### Install using Emissary-Ingress CRDs
+
+```bash
+./test_emissary_ingress.sh
+```
+
+### Install using classic Kubernetes ingress API
+
+```bash
+./test_classic_ingress.sh
+```
+
+## Cleanup
+
+### Delete resources for Apache HTTPd with Emissary-Ingress CRDs
+
+```bash
+# delete resources for classic ingress 
+kubectl delete namespace "emissary-ingress-test"
+```
+
+
+### Delete resources for Apache HTTPd with classic Kubernetes ingress API
+
+```bash
+# delete resources for classic ingress 
+kubectl delete namespace "ingress-test"
+```

--- a/kubernetes/gke/ingress/ambassador/example/apache/test_classic_ingress.sh
+++ b/kubernetes/gke/ingress/ambassador/example/apache/test_classic_ingress.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env
+# deploy application 
+kubectl create namespace "ingress-test"
+kubectl create deployment httpd \
+  --image "httpd" \
+  --replicas 3 \
+  --port 80 \
+  --namespace "ingress-test"
+
+# create proxy to deployment
+kubectl expose deployment httpd \
+  --port 80 \
+  --target-port 80 \
+  --type ClusterIP \
+  --namespace "ingress-test"
+
+# provision application load balancer
+kubectl create ingress httpd-ingress \
+  --rule "ingress.test/=httpd:80" \
+  --annotation "kubernetes.io/ingress.class=ambassador" \
+  --class "ambassador" \
+  --namespace "ingress-test"

--- a/kubernetes/gke/ingress/ambassador/example/apache/test_emissary_ingress.sh
+++ b/kubernetes/gke/ingress/ambassador/example/apache/test_emissary_ingress.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env
+
+TEST_EMISSARY_INGRESS_FQDN="emissary.ingress.test"
+
+# deploy application 
+kubectl create namespace "emissary-ingress-test"
+kubectl create deployment httpd \
+  --image "httpd" \
+  --replicas 3 \
+  --port 80 \
+  --namespace "emissary-ingress-test"
+
+# create proxy to deployment
+kubectl expose deployment httpd \
+  --port 80 \
+  --target-port 80 \
+  --type ClusterIP \
+  --namespace "emissary-ingress-test"
+
+kubectl apply --namespace emissary-ingress-test --filename - <<EOF
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name:  emissary-ingress-test
+spec:
+  hostname: "*"
+  requestPolicy:
+    insecure:
+      action: Route
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name:  emissary-ingress-test
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: INSECURE
+  hostBinding:
+    namespace:
+      from: SELF
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name:  emissary-ingress-test
+spec:
+  hostname: $TEST_EMISSARY_INGRESS_FQDN
+  prefix: /
+  service: http://httpd.emissary-ingress-test:80
+EOF

--- a/kubernetes/gke/ingress/ambassador/example/dgraph/README.md
+++ b/kubernetes/gke/ingress/ambassador/example/dgraph/README.md
@@ -1,0 +1,46 @@
+# Dgraph
+
+Dgraph is a highly performant distributed graph database. The following ports are used for externals communication with Dgraph Alpha
+
+* port `8080`: http/1.1 for GraphQL or DQL
+* Port `9080`: gRPC (http/2) for DQL
+
+## Install
+
+### Installation with Emissary-Ingress CRDs
+
+Setup environment variables as needed:
+
+```bash
+export DGRAPH_HOSTNAME_HTTP="dgraph.local"
+export DGRAPH_RELEASE_NAME="dg"
+export DGRAPH_ALLOW_LIST="0.0.0.0/0"
+
+# Install Dgraph 
+./dgraph_install.sh
+
+# Install Dgraph using Emissary-Ingress CRDs
+./dgraph_emissary_ingress.sh
+```
+
+### Installation with classic legacy ingress API
+
+Setup environment variables as needed:
+
+```bash
+export DGRAPH_HOSTNAME_HTTP="dgraph.local"
+export DGRAPH_RELEASE_NAME="dg"
+export DGRAPH_ALLOW_LIST="0.0.0.0/0"
+
+# Install Dgraph 
+./dgraph/dgraph_install.sh
+
+# Install Dgraph using Emissary-Ingress CRDs
+./dgraph_classic_ingress.sh
+```
+
+## Cleanup
+
+```bash
+./dgraph_clean.sh
+```

--- a/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_classic_ingress.sh
+++ b/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_classic_ingress.sh
@@ -1,0 +1,24 @@
+export DGRAPH_HOSTNAME_HTTP=${DGRAPH_HOSTNAME_HTTP:-"dgraph.local"}
+export DGRAPH_RELEASE_NAME=${DGRAPH_RELEASE_NAME:-"dg"}
+
+kubectl apply --namespace dgraph --filename - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: $DGRAPH_RELEASE_NAME-dgraph-ingress
+  annotations:
+    kubernetes.io/ingress.class: ambassador
+spec:
+  ingressClassName: ambassador
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name:  $DGRAPH_RELEASE_NAME-dgraph-alpha
+                port:
+                  number: 8080
+            pathType: ImplementationSpecific
+            path: /
+      host: $DGRAPH_HOSTNAME_HTTP
+EOF

--- a/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_clean.sh
+++ b/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_clean.sh
@@ -1,0 +1,5 @@
+
+RELEASE_NAME=${RELEASE_NAME:-"dg"}
+helm delete $RELEASE_NAME --namespace dgraph
+kubectl delete pvc --namespace dgraph --selector release=$RELEASE_NAME
+kubectl delete namespace dgraph

--- a/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_emissary_ingress.sh
+++ b/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_emissary_ingress.sh
@@ -1,0 +1,52 @@
+export DGRAPH_HOSTNAME_HTTP=${DGRAPH_HOSTNAME_HTTP:-"dgraph.local"}
+export DGRAPH_RELEASE_NAME=${DGRAPH_RELEASE_NAME:-"dg"}
+
+kubectl apply --namespace dgraph --filename - <<EOF
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: $DGRAPH_RELEASE_NAME-dgraph
+spec:
+  hostname: "*"
+  requestPolicy:
+    insecure:
+      action: Route
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: $DGRAPH_RELEASE_NAME-dgraph
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: INSECURE
+  hostBinding:
+    namespace:
+      from: SELF
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: $DGRAPH_RELEASE_NAME-dgraph-http
+spec:
+  hostname: $DGRAPH_HOSTNAME
+  prefix: /
+  service: $DGRAPH_RELEASE_NAME-dgraph-alpha.dgraph:8080
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: $DGRAPH_RELEASE_NAME-dgraph-grpc
+spec:
+  hostname: "*"
+  prefix: /api.Dgraph/
+  rewrite: /api.Dgraph/
+  service: $DGRAPH_RELEASE_NAME-dgraph-alpha.dgraph:9080
+  grpc: True
+EOF
+
+curl -sOL https://raw.githubusercontent.com/dgraph-io/pydgraph/master/pydgraph/proto/api.proto
+grpcurl -plaintext -proto api.proto grpc.dgraph.local:80 api.Dgraph/CheckVersion
+
+kubectl get Listener,Mapping,Host

--- a/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_install.sh
+++ b/kubernetes/gke/ingress/ambassador/example/dgraph/dgraph_install.sh
@@ -1,0 +1,20 @@
+export DGRAPH_ALLOW_LIST=${DGRAPH_ALLOW_LIST:-"0.0.0.0/0"}
+export DGRAPH_RELEASE_NAME=${DGRAPH_RELEASE_NAME:-"dg"}
+
+helm install $DGRAPH_RELEASE_NAME dgraph/dgraph \
+  --namespace dgraph \
+  --create-namespace \
+  --values -  <<EOF
+zero:
+  persistence:
+    storageClass: premium-rwo
+    size: 10Gi
+alpha:
+  configFile:
+    config.yaml: |
+      security:
+        whitelist: ${DGRAPH_ALLOW_LIST}
+  persistence:
+    storageClass: premium-rwo
+    size: 30Gi
+EOF


### PR DESCRIPTION
This adds instructions for Emissary-Ingress (aka Ambassador) with examples for Dgraph and Apache HTTPd to demonstrate classic Kubernetes ingress API as well as Emissary-Ingress CRDs with Host, Listener, and Mapping.