### PR TITLE
vault/approle/dgraph - update unseal script

### DIFF
--- a/vault-docker/approle/dgraph/README.md
+++ b/vault-docker/approle/dgraph/README.md
@@ -80,11 +80,13 @@ mkdir -p $VAULT_CONFIG_DIR
 docker compose up --detach "vault"
 
 # Unseal vault
+export VAULT_ADDR="http://localhost:8200"
 ./scripts/unseal.sh
+
+
 export VAULT_ROOT_TOKEN="$(
   grep -oP "(?<=Initial Root Token: ).*" $VAULT_CONFIG_DIR/unseal.creds
 )"
-export VAULT_ADDR="http://localhost:8200"
 ```
 
 From this point, chose whether you wish to use the Vault REST API using `curl` or using the `vault` CLI to interact with the Vault server.
@@ -110,7 +112,7 @@ curl --silent --header "X-Vault-Token: $VAULT_ROOT_TOKEN" \
 ################
 $VAULT_SCRIPTS/3.policies.sh
 # verify  policies
-BAT_CMD=$(command -v bat > /dev/null && echo "$(command -v bat) --language hcl")
+BAT_CMD=$(command -v bat > /dev/null && echo "$(command -v bat) --language hcl --paging=never" )
 curl --silent --header "X-Vault-Token: $VAULT_ROOT_TOKEN" \
   $VAULT_ADDR/v1/sys/policies/acl/admin | jq .data.policy \
   | sed -r -e 's/\\n/\n/g' -e 's/\\"/"/g' -e 's/^"(.*)"$/\1/' \
@@ -163,7 +165,7 @@ vault secrets list
 ################
 $VAULT_SCRIPTS/3.policies.sh
 # verify  policies
-BAT_CMD=$(command -v bat > /dev/null && echo "$(command -v bat) --language hcl")
+BAT_CMD=$(command -v bat > /dev/null && echo "$(command -v bat) --language hcl --paging=never")
 vault policy read admin | $BAT_CMD
 vault policy read dgraph | $BAT_CMD
 
@@ -220,7 +222,9 @@ export DGRAPH_ADMIN_USER="groot"
 export DGRAPH_ADMIN_PSWD="password"
 export DGRAPH_HTTP="localhost:8080"
 DGRAPH_SCRIPTS=./scripts/dgraph
+
 $DGRAPH_SCRIPTS/login.sh
+
 export DGRAPH_TOKEN=$(cat $DGRAPH_CONFIG_DIR/.dgraph.token)
 
 ############################################
@@ -228,6 +232,7 @@ export DGRAPH_TOKEN=$(cat $DGRAPH_CONFIG_DIR/.dgraph.token)
 ############################################
 $DGRAPH_SCRIPTS/getting_started/1.data_json.sh
 $DGRAPH_SCRIPTS/getting_started/2.schema.sh
+
 $DGRAPH_SCRIPTS/getting_started/3.query_starring_edge.sh
 $DGRAPH_SCRIPTS/getting_started/4.query_movies_after_1980.sh
 
@@ -271,13 +276,25 @@ unset VAULT_ROOT_TOKEN VAULT_ADDR VAULT_SCRIPTS VAULT_CONFIG_DIR TEMP_DIR \
 
 These are the environments that were tested on April, 2024.
 
-### macOS Monterey 12.6.3 build 21G419
+### macOS Monterey 12.6.3 build 21G419 (Apple M1 Max)
 --------------------------------------------------
 * **Docker Desktop for macOS** 4.29.0
   * **Docker Engine** 26.0.0
     * Plugin: **Compose** v2.26.1
 * **zsh** 5.9 (arm-apple-darwin21.3.0)
 * **GNU bash**, version 5.2.21(1)-release (aarch64-apple-darwin21.6.0)
+* grep (**GNU grep**) 3.11
+* sed (**GNU sed**) 4.9
+* **jq** 1.7.1
+* **Vault** v1.16.2
+
+### macOS Monterey 12.2.1 build 21D62 (Intel Core i5)
+--------------------------------------------------
+* **Docker Desktop for macOS** 4.12.0
+  * **Docker Engine** 20.10.17
+    * Plugin: **Compose** v2.10.2
+* **zsh** 5.9 (x86_64-apple-darwin21.3.0)
+* **GNU bash**, version 5.2.26(1)-release (x86_64-apple-darwin21.6.0)
 * grep (**GNU grep**) 3.11
 * sed (**GNU sed**) 4.9
 * **jq** 1.7.1

--- a/vault-docker/approle/dgraph/scripts/dgraph/login.sh
+++ b/vault-docker/approle/dgraph/scripts/dgraph/login.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-command -v grep > /dev/null || \
-  { echo "[ERROR]: 'grep' command not not found" 1>&2; exit 1; }
+grep --version | grep -q GNU  || \
+  { echo "[ERROR]: GNU grep command not not found" 1>&2; exit 1; }
 command -v curl > /dev/null || \
   { echo "[ERROR]: 'curl' command not not found" 1>&2; exit 1; }
 

--- a/vault-docker/approle/dgraph/scripts/unseal.sh
+++ b/vault-docker/approle/dgraph/scripts/unseal.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-command -v grep > /dev/null || \
-  { echo "[ERROR]: 'grep' command not not found" 1>&2; exit 1; }
+grep --version | grep -q GNU  || \
+  { echo "[ERROR]: GNU grep command not not found" 1>&2; exit 1; }
 command -v vault > /dev/null || \
   { echo "[ERROR]: 'vault' command not not found" 1>&2; exit 1; }
 
 export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
 export VAULT_CONFIG_DIR=${VAULT_CONFIG_DIR:-"./vault"}
 mkdir -p $VAULT_CONFIG_DIR
-echo $VAULT_CONFIG_DIR
+
+# initialize
+vault operator init | tee $VAULT_CONFIG_DIR/unseal.creds
 
 # unseal
-vault operator init | tee $VAULT_CONFIG_DIR/unseal.creds
-for NUM in {1..3}; do
-  vault operator unseal \
-    $(grep -oP "(?<=Unseal Key $NUM: ).*" $VAULT_CONFIG_DIR/unseal.creds)
+NUM=1 
+until [[ "$SEALED" == "false" ]]; do
+  SEALED=$(
+    vault operator unseal \
+        $(grep -oP "(?<=Unseal Key $NUM: ).*" $VAULT_CONFIG_DIR/unseal.creds) \
+      | awk '/Sealed/{ print $2 }'
+  )
+  let NUM="$NUM + 1" 
 done

--- a/vault-docker/approle/dgraph/scripts/vault_api/2.configure.sh
+++ b/vault-docker/approle/dgraph/scripts/vault_api/2.configure.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 command -v vault > /dev/null || \
   { echo "[ERROR]: 'vault' command not not found" 1>&2; exit 1; }
-
+command -v jq > /dev/null || \
+  { echo "[ERROR]: 'jq' command not not found" 1>&2; exit 1; }
 [[ -z "$VAULT_ROOT_TOKEN" ]] && { echo 'VAULT_ROOT_TOKEN not specified. Aborting' 2>&1 ; exit 1; }
 export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
 

--- a/vault-docker/approle/dgraph/scripts/vault_api/5.secrets_dgraph_create.sh
+++ b/vault-docker/approle/dgraph/scripts/vault_api/5.secrets_dgraph_create.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 command -v vault > /dev/null || \
   { echo "[ERROR]: 'vault' command not not found" 1>&2; exit 1; }
-
+command -v jq > /dev/null || \
+  { echo "[ERROR]: 'jq' command not not found" 1>&2; exit 1; }
 [[ -z "$VAULT_ROOT_TOKEN" ]] && { echo 'VAULT_ROOT_TOKEN not specified. Aborting' 2>&1 ; exit 1; }
 export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
 

--- a/vault-docker/approle/dgraph/scripts/vault_api/6.secrets_dgraph_read.sh
+++ b/vault-docker/approle/dgraph/scripts/vault_api/6.secrets_dgraph_read.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 command -v vault > /dev/null || \
   { echo "[ERROR]: 'vault' command not not found" 1>&2; exit 1; }
-
+command -v jq > /dev/null || \
+  { echo "[ERROR]: 'jq' command not not found" 1>&2; exit 1; }
 export VAULT_CONFIG_DIR=${VAULT_CONFIG_DIR:-"./vault"}
 export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
 [[ -f "$VAULT_CONFIG_DIR/.admin.token" ]] || { echo "'$VAULT_CONFIG_DIR/.admin.token' is not found. Aborting" 2>&1 ; exit 1; }

--- a/vault-docker/approle/dgraph/scripts/vault_cli/5.secrets_dgraph_create.sh
+++ b/vault-docker/approle/dgraph/scripts/vault_cli/5.secrets_dgraph_create.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 command -v vault > /dev/null || \
   { echo "[ERROR]: 'vault' command not not found" 1>&2; exit 1; }
-
+command -v jq > /dev/null || \
+  { echo "[ERROR]: 'jq' command not not found" 1>&2; exit 1; }
 [[ -z "$VAULT_ROOT_TOKEN" ]] && { echo 'VAULT_ROOT_TOKEN not specified. Aborting' 2>&1 ; exit 1; }
 export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
 vault login $VAULT_ROOT_TOKEN

--- a/vault-docker/approle/dgraph/scripts/vault_cli/6.secrets_dgraph_read.sh
+++ b/vault-docker/approle/dgraph/scripts/vault_cli/6.secrets_dgraph_read.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 command -v vault > /dev/null || \
   { echo "[ERROR]: 'vault' command not not found" 1>&2; exit 1; }
-
+command -v jq > /dev/null || \
+  { echo "[ERROR]: 'jq' command not not found" 1>&2; exit 1; }
 export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
 [[ -f "$VAULT_CONFIG_DIR/.admin.token" ]] || { echo "'$VAULT_CONFIG_DIR/.admin.token' is not found. Aborting" 2>&1 ; exit 1; }
 export VAULT_ADMIN_TOKEN=$(cat $VAULT_CONFIG_DIR/.admin.token)


### PR DESCRIPTION
Small updates for Hashicorp Vault AppRole update with Dgraph client example.

* disable paging for `bat` command
* add intel macbook to test environments
* check for `grep` will now assume grep is installed, but check for GNU grep
* check for `jq` added to scripts that use `jq`
* unseal.sh script will now loop until vault is unsealed, not assume only 3 unseal operations are needed.